### PR TITLE
Add Release workflow to publish GitHub Releases on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Needed for `gh release create` to publish a GitHub Release.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Verify tag matches package version
+      run: |
+        version="${GITHUB_REF_NAME#v}"
+        pkg_version="$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+        if [ "$version" != "$pkg_version" ]; then
+          echo "::error::Tag ${GITHUB_REF_NAME} (${version}) does not match pyproject.toml version (${pkg_version})."
+          exit 1
+        fi
+        echo "Tag ${GITHUB_REF_NAME} matches package version ${pkg_version}."
+
+    - name: Extract release notes from CHANGELOG
+      id: notes
+      run: |
+        version="${GITHUB_REF_NAME#v}"
+        notes_file="$(mktemp)"
+        # Pull the section for this version out of CHANGELOG.md (everything
+        # between "## [<version>]" and the next "## " heading).
+        awk -v ver="$version" '
+          $0 ~ "^## \\[" ver "\\]" { capture = 1; next }
+          capture && /^## / { exit }
+          capture { print }
+        ' CHANGELOG.md > "$notes_file"
+        if [ ! -s "$notes_file" ]; then
+          echo "Release ${GITHUB_REF_NAME}." > "$notes_file"
+        fi
+        echo "file=${notes_file}" >> "$GITHUB_OUTPUT"
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "$GITHUB_REF_NAME" \
+          --repo "$GITHUB_REPOSITORY" \
+          --title "$GITHUB_REF_NAME" \
+          --notes-file "${{ steps.notes.outputs.file }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,10 @@ The version is defined **once**, in `pyproject.toml`. Both
 MCP handshake) read it from the installed package metadata via
 `importlib.metadata.version("mochi-donut")`, so they never drift. To cut a
 release: bump `version` in `pyproject.toml`, add a `CHANGELOG.md` entry, and
-tag the commit (`vX.Y.Z`). Pre-1.0, minor bumps may include behavioral changes.
+push a `vX.Y.Z` tag. Pushing the tag triggers `.github/workflows/release.yml`,
+which verifies the tag matches the `pyproject.toml` version and publishes a
+GitHub Release with notes pulled from the matching `CHANGELOG.md` section.
+Pre-1.0, minor bumps may include behavioral changes.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so future releases publish themselves when you push a `vX.Y.Z` tag — no manual GitHub Release step, and no dependence on an environment that can push tags by hand.

On a `v*` tag push, the workflow:
1. **Verifies the tag matches `pyproject.toml`** — fails fast if `v0.3.0` is pushed while the package says something else, keeping the single-source-of-truth honest.
2. **Extracts release notes** from the matching `## [<version>]` section of `CHANGELOG.md` (falls back to a minimal note if absent).
3. **Publishes a GitHub Release** via the runner's built-in `gh` CLI + `GITHUB_TOKEN` (`contents: write`). No third-party actions, no PyPI credentials.

## Release flow going forward
```bash
# bump version in pyproject.toml, add a CHANGELOG.md entry, commit, merge to main, then:
git tag -a v0.3.1 -m "v0.3.1"
git push origin v0.3.1   # ← workflow creates the GitHub Release automatically
```

Also documented this in `CLAUDE.md`.

## Notes
- This does **not** publish to PyPI — that would need PyPI trusted-publishing/credentials set up on the repo, which is out of scope here. Easy to add later as a second job if you want it.
- Validated the workflow YAML and tested the CHANGELOG-extraction and version-parse logic locally against the current `CHANGELOG.md` (0.3.0).
- **Still outstanding:** the `v0.3.0` tag/release itself — push that tag once this is merged and it'll be the first release this workflow publishes. (The `0.3.0` CHANGELOG entry is already on `main`.)

https://claude.ai/code/session_01F3iyzud42M5TWx8xUupUnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3iyzud42M5TWx8xUupUnK)_