### PR TITLE
fix: add required trailing slash to Mochi API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ The version is defined once in `pyproject.toml`; the package and the running
 MCP server (`serverInfo.version`) both read it from the installed package
 metadata, so it never drifts.
 
+## [0.3.1]
+
+### Fixed
+- **Mochi API 404s**: `list_decks` and `create_cards` now request
+  `/api/decks/` and `/api/cards/` with the trailing slash Mochi's router
+  requires. Without it the router returns `404 Not Found` even with a valid
+  API key.
+
 ## [0.3.0]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mochi-donut"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for converting web content into Mochi flashcards"
 readme = "README.md"
 authors = [

--- a/src/mochi_donut/server.py
+++ b/src/mochi_donut/server.py
@@ -319,7 +319,9 @@ async def _list_decks_impl() -> str:
 
     # Mochi uses HTTP Basic auth: API key as username, blank password.
     async with httpx.AsyncClient(auth=(api_key, "")) as client:
-        response = await client.get(f"{MOCHI_API_BASE}/decks")
+        # The trailing slash is required: Mochi's router 404s on /api/decks
+        # but resolves /api/decks/ (see https://mochi.cards/docs/api/).
+        response = await client.get(f"{MOCHI_API_BASE}/decks/")
         response.raise_for_status()
 
         decks = response.json()
@@ -357,8 +359,10 @@ async def _create_cards_impl(deck_id: str, cards: list[dict]) -> str:
                 # Mochi renders a two-sided card from a single markdown `content`
                 # field, with the "---" separator dividing front (question) from
                 # back (answer). This works for any deck without needing a template.
+                # The trailing slash is required: Mochi's router 404s on
+                # /api/cards but resolves /api/cards/.
                 response = await client.post(
-                    f"{MOCHI_API_BASE}/cards",
+                    f"{MOCHI_API_BASE}/cards/",
                     json={
                         "deck-id": deck_id,
                         "content": f"{card['question']}\n---\n{card['answer']}",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,12 +169,15 @@ class TestListDecksTool:
             "docs": [{"id": "deck-1", "name": "Python"}, {"id": "deck-2", "name": "JavaScript"}]
         }
 
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        # Mochi's router requires the trailing slash: /api/decks/ 200s while
+        # /api/decks 404s even with a valid key.
+        route = respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json=mock_response)
         )
 
         result = await _list_decks_impl()
 
+        assert route.calls.last.request.url.path == "/api/decks/"
         assert "Python: deck-1" in result
         assert "JavaScript: deck-2" in result
 
@@ -184,7 +187,7 @@ class TestListDecksTool:
         """Test empty deck list."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json={"docs": []})
         )
 
@@ -210,7 +213,7 @@ class TestCreateCardsTool:
         """Test successful card creation."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.post("https://app.mochi.cards/api/cards").mock(
+        respx.post("https://app.mochi.cards/api/cards/").mock(
             return_value=Response(200, json={"id": "card-123"})
         )
 
@@ -232,7 +235,7 @@ class TestCreateCardsTool:
 
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        route = respx.post("https://app.mochi.cards/api/cards").mock(
+        route = respx.post("https://app.mochi.cards/api/cards/").mock(
             return_value=Response(200, json={"id": "card-123"})
         )
 
@@ -242,6 +245,9 @@ class TestCreateCardsTool:
 
         request = route.calls.last.request
         body = json.loads(request.content)
+
+        # Mochi's router requires the trailing slash on /api/cards/.
+        assert request.url.path == "/api/cards/"
 
         # Tags use Mochi's "manual-tags" key.
         assert body["manual-tags"] == ["python", "basics"]
@@ -272,7 +278,7 @@ class TestCreateCardsTool:
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
         # First card succeeds, second fails
-        route = respx.post("https://app.mochi.cards/api/cards")
+        route = respx.post("https://app.mochi.cards/api/cards/")
         route.side_effect = [
             Response(200, json={"id": "card-1"}),
             Response(400, text="Invalid card"),
@@ -304,7 +310,7 @@ class TestCreateCardsTool:
         """Non-HTTPStatusError exceptions are captured in the error list."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.post("https://app.mochi.cards/api/cards").mock(side_effect=httpx.ConnectError("boom"))
+        respx.post("https://app.mochi.cards/api/cards/").mock(side_effect=httpx.ConnectError("boom"))
 
         result = await _create_cards_impl("deck-1", [{"question": "Q1", "answer": "A1"}])
 
@@ -379,7 +385,7 @@ class TestToolWrappers:
     @pytest.mark.asyncio
     async def test_list_decks_tool_wrapper(self, monkeypatch):
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json={"docs": []})
         )
         assert "No decks found" in await list_decks()

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "mochi-donut"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

`list_decks` (and, latently, `create_cards`) hit **404 Not Found** against the live Mochi API. Root cause: Mochi's router requires a **trailing slash** — `/api/decks/` resolves, `/api/decks` 404s even with a valid API key. The server was requesting the no-slash paths.

## Verification (before fixing)

- Reproduced on the live MCP instance: `Client error '404 Not Found' for url 'https://app.mochi.cards/api/decks'`.
- Confirmed against [Mochi's API docs](https://mochi.cards/docs/api/) — every documented example uses `https://app.mochi.cards/api/decks/` and `/api/cards/`.
- Note: a dummy-key probe 404s on *both* URL forms (`{"errors":["Invalid API key."]}`), because the auth layer rejects before routing — only a valid key exposes the quirk.

## Changes

- `_list_decks_impl` → `GET /api/decks/`
- `_create_cards_impl` → `POST /api/cards/` (same latent bug, same fix)
- Tests: the respx mocks previously targeted the no-slash URLs, so they rubber-stamped the bug at 100% coverage. Updated to the slashed paths and added explicit `request.url.path` assertions so the contract is regression-proof.
- Bumped to `0.3.1` + CHANGELOG entry.

## Testing

- `uv run pytest` → 33 passed, 100% line & branch coverage.
- TDD red→green: tests fail against the old code (`RESPX: ...'/api/decks' not mocked!`), pass after the fix.
- `vet` → no issues.

⚠️ Live confirmation of the *fixed* code against the real API requires restarting the MCP server (to reload the edited source) and calling `list_decks`; the running instance still holds the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)