### PR TITLE
Add card and deck management tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ The version is defined once in `pyproject.toml`; the package and the running
 MCP server (`serverInfo.version`) both read it from the installed package
 metadata, so it never drifts.
 
+## [0.3.1]
+
+### Fixed
+- **Mochi API 404s**: `list_decks` and `create_cards` now request
+  `/api/decks/` and `/api/cards/` with the trailing slash Mochi's router
+  requires. Without it the router returns `404 Not Found` even with a valid
+  API key.
+
 ## [0.3.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ The version is defined once in `pyproject.toml`; the package and the running
 MCP server (`serverInfo.version`) both read it from the installed package
 metadata, so it never drifts.
 
+## [0.4.0]
+
+### Added
+- **Card management**: `list_cards` (browse/search, optionally scoped to a
+  deck, with `bookmark`-based pagination), `get_card` (full content, deck-id,
+  and tags), `update_card` (partial updates to content, deck, manual tags,
+  `archived?`, and `trashed?` — soft-delete uses an ISO 8601 timestamp, not
+  a boolean).
+- **Deck management**: `create_deck` (with optional `parent-id` nesting) and
+  `update_deck` (partial updates to name, parent, and `archived?`).
+- **Attachments**: `add_attachment` uploads a local image
+  (png/jpg/jpeg/gif/svg/webp) to a card via multipart/form-data, inferring
+  the filename and content-type; reference it in card content with
+  `![](@media/<filename>)`.
+
 ## [0.3.1]
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ src/mochi_donut/
 ```
 
 The server exposes:
-- **Tools**: `fetch_url` (JinaAI Reader), `list_decks`, `create_cards` (Mochi API)
+- **Tools**: `fetch_url` (JinaAI Reader); `list_decks`, `create_cards`,
+  `list_cards`, `get_card`, `update_card`, `create_deck`, `update_deck`,
+  `add_attachment` (Mochi API)
 - **Resources**: `matuschak://principles`, `matuschak://examples`
 - **Prompts**: `generate_flashcards`, `review_flashcards`
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ An MCP server that converts web content into high-quality Mochi flashcards follo
 - **fetch_url** - Extract clean markdown from any URL via JinaAI Reader
 - **list_decks** - List your Mochi decks
 - **create_cards** - Create flashcards in Mochi (single or batch)
+- **list_cards** - Browse or search existing cards, optionally scoped to a deck
+- **get_card** - Fetch a single card's full content, deck, and tags
+- **update_card** - Edit a card's content, deck, tags, archived, or trashed status
+- **create_deck** - Create a new deck, optionally nested under a parent
+- **update_deck** - Rename, re-nest, or archive a deck
+- **add_attachment** - Attach a local image file to a card
 - Built-in resources with Matuschak's flashcard writing principles
 - Prompt templates for generating and reviewing flashcards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mochi-donut"
-version = "0.3.1"
+version = "0.4.0"
 description = "MCP server for converting web content into Mochi flashcards"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mochi-donut"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for converting web content into Mochi flashcards"
 readme = "README.md"
 authors = [

--- a/src/mochi_donut/server.py
+++ b/src/mochi_donut/server.py
@@ -319,7 +319,9 @@ async def _list_decks_impl() -> str:
 
     # Mochi uses HTTP Basic auth: API key as username, blank password.
     async with httpx.AsyncClient(auth=(api_key, "")) as client:
-        response = await client.get(f"{MOCHI_API_BASE}/decks")
+        # The trailing slash is required: Mochi's router 404s on /api/decks
+        # but resolves /api/decks/ (see https://mochi.cards/docs/api/).
+        response = await client.get(f"{MOCHI_API_BASE}/decks/")
         response.raise_for_status()
 
         decks = response.json()
@@ -357,8 +359,10 @@ async def _create_cards_impl(deck_id: str, cards: list[dict]) -> str:
                 # Mochi renders a two-sided card from a single markdown `content`
                 # field, with the "---" separator dividing front (question) from
                 # back (answer). This works for any deck without needing a template.
+                # The trailing slash is required: Mochi's router 404s on
+                # /api/cards but resolves /api/cards/.
                 response = await client.post(
-                    f"{MOCHI_API_BASE}/cards",
+                    f"{MOCHI_API_BASE}/cards/",
                     json={
                         "deck-id": deck_id,
                         "content": f"{card['question']}\n---\n{card['answer']}",

--- a/src/mochi_donut/server.py
+++ b/src/mochi_donut/server.py
@@ -7,7 +7,8 @@ A focused MCP server for converting web content into high-quality Mochi flashcar
 following Andy Matuschak's spaced repetition principles.
 
 Components:
-- Tools: fetch_url, list_decks, create_cards
+- Tools: fetch_url, list_decks, create_cards, list_cards, get_card,
+  update_card, create_deck, update_deck, add_attachment
 - Resources: Matuschak's principles, example flashcards
 - Prompts: Flashcard generation workflow
 
@@ -24,7 +25,9 @@ Or run directly: uv run python -m mochi_donut.server
 """
 
 import os
+from datetime import UTC, datetime
 from importlib.metadata import version
+from pathlib import Path
 
 import httpx
 from fastmcp import FastMCP
@@ -37,6 +40,17 @@ __version__ = version("mochi-donut")
 JINA_READER_BASE = "https://r.jina.ai"
 MOCHI_API_BASE = "https://app.mochi.cards/api"
 
+# Maps supported attachment extensions to their MIME content-type, per
+# Mochi's attachment endpoint (https://mochi.cards/docs/api/).
+ATTACHMENT_CONTENT_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "svg": "image/svg+xml",
+    "webp": "image/webp",
+}
+
 # Server instructions for the agent
 SERVER_INSTRUCTIONS = """You are a flashcard generation assistant. Your goal is to help users
 convert web content into high-quality Mochi flashcards following Andy Matuschak's principles.
@@ -48,6 +62,11 @@ Typical workflow:
 4. Generate flashcards following those principles
 5. Use list_decks to find the target deck
 6. Use create_cards to save the flashcards to Mochi
+
+You can also manage existing cards and decks: list_cards and get_card to
+browse and inspect, update_card to edit content/tags/deck/archived/trashed
+status, create_deck and update_deck to manage decks, and add_attachment to
+attach an image file to a card.
 
 Always prioritize understanding over memorization. Create focused, specific prompts."""
 
@@ -385,6 +404,256 @@ async def _create_cards_impl(deck_id: str, cards: list[dict]) -> str:
     return result
 
 
+async def _list_cards_impl(
+    deck_id: str | None = None, limit: int = 100, bookmark: str | None = None
+) -> str:
+    """
+    Core implementation for listing Mochi cards.
+
+    Args:
+        deck_id: Only return cards from this deck, if given
+        limit: Maximum number of cards to return per page (1-100)
+        bookmark: Pagination cursor returned by a previous call
+
+    Returns:
+        Formatted list of card IDs and first content line, plus a bookmark
+        for the next page when more results are available
+    """
+    api_key = _get_mochi_api_key()
+
+    params: dict[str, str | int] = {"limit": limit}
+    if deck_id is not None:
+        params["deck-id"] = deck_id
+    if bookmark is not None:
+        params["bookmark"] = bookmark
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        # The trailing slash is required: Mochi's router 404s on /api/cards
+        # but resolves /api/cards/ (see https://mochi.cards/docs/api/).
+        response = await client.get(f"{MOCHI_API_BASE}/cards/", params=params)
+        response.raise_for_status()
+
+        data = response.json()
+
+    docs = data.get("docs", [])
+    if not docs:
+        return "No cards found."
+
+    lines = [f"{card['id']}: {card.get('content', '').split(chr(10), 1)[0]}" for card in docs]
+    result = "\n".join(lines)
+
+    next_bookmark = data.get("bookmark")
+    if next_bookmark:
+        result += f"\n\nbookmark: {next_bookmark}"
+
+    return result
+
+
+async def _get_card_impl(card_id: str) -> str:
+    """
+    Core implementation for fetching a single Mochi card.
+
+    Args:
+        card_id: The Mochi card ID
+
+    Returns:
+        The card's deck-id, tags, and full markdown content
+    """
+    api_key = _get_mochi_api_key()
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        response = await client.get(f"{MOCHI_API_BASE}/cards/{card_id}")
+        response.raise_for_status()
+
+        card = response.json()
+
+    tags = card.get("tags") or []
+    manual_tags = card.get("manual-tags") or []
+
+    lines = [
+        f"id: {card['id']}",
+        f"deck-id: {card.get('deck-id', '')}",
+        f"tags: {', '.join(tags) if tags else 'none'}",
+        f"manual-tags: {', '.join(manual_tags) if manual_tags else 'none'}",
+        "",
+        card.get("content", ""),
+    ]
+    return "\n".join(lines)
+
+
+async def _update_card_impl(
+    card_id: str,
+    content: str | None = None,
+    deck_id: str | None = None,
+    manual_tags: list[str] | None = None,
+    archived: bool | None = None,
+    trashed: bool | None = None,
+) -> str:
+    """
+    Core implementation for updating a Mochi card.
+
+    Only the provided fields are sent to the API, mapped to Mochi's
+    kebab-case field names.
+
+    Args:
+        card_id: The Mochi card ID
+        content: New markdown content, if changing
+        deck_id: Move the card to this deck, if given
+        manual_tags: Replace the card's manual tags, if given
+        archived: Set the card's archived status, if given
+        trashed: Soft-delete (True) or restore (False) the card, if given.
+            Mochi represents this as a timestamp, not a boolean: True stamps
+            the current time, False clears it.
+
+    Returns:
+        Confirmation message, or a note that nothing was provided to update
+    """
+    api_key = _get_mochi_api_key()
+
+    payload: dict[str, object] = {}
+    if content is not None:
+        payload["content"] = content
+    if deck_id is not None:
+        payload["deck-id"] = deck_id
+    if manual_tags is not None:
+        payload["manual-tags"] = manual_tags
+    if archived is not None:
+        payload["archived?"] = archived
+    if trashed is not None:
+        # Mochi's "trashed?" field is an ISO 8601 timestamp (soft delete),
+        # not a boolean: stamp "now" to trash, send null to untrash.
+        payload["trashed?"] = (
+            datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z" if trashed else None
+        )
+
+    if not payload:
+        return "No fields provided to update."
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        response = await client.post(f"{MOCHI_API_BASE}/cards/{card_id}", json=payload)
+        response.raise_for_status()
+
+    return f"Updated card {card_id}."
+
+
+async def _create_deck_impl(name: str, parent_id: str | None = None) -> str:
+    """
+    Core implementation for creating a Mochi deck.
+
+    Args:
+        name: The deck name
+        parent_id: Nest the new deck under this parent deck, if given
+
+    Returns:
+        Confirmation message with the created deck's name and ID
+    """
+    api_key = _get_mochi_api_key()
+
+    payload: dict[str, str] = {"name": name}
+    if parent_id is not None:
+        payload["parent-id"] = parent_id
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        # The trailing slash is required: Mochi's router 404s on /api/decks
+        # but resolves /api/decks/ (see https://mochi.cards/docs/api/).
+        response = await client.post(f"{MOCHI_API_BASE}/decks/", json=payload)
+        response.raise_for_status()
+
+        deck = response.json()
+
+    return f"Created deck '{deck['name']}': {deck['id']}"
+
+
+async def _update_deck_impl(
+    deck_id: str,
+    name: str | None = None,
+    parent_id: str | None = None,
+    archived: bool | None = None,
+) -> str:
+    """
+    Core implementation for updating a Mochi deck.
+
+    Only the provided fields are sent to the API, mapped to Mochi's
+    kebab-case field names.
+
+    Args:
+        deck_id: The Mochi deck ID
+        name: New deck name, if changing
+        parent_id: Move the deck under this parent deck, if given
+        archived: Set the deck's archived status, if given
+
+    Returns:
+        Confirmation message, or a note that nothing was provided to update
+    """
+    api_key = _get_mochi_api_key()
+
+    payload: dict[str, str | bool] = {}
+    if name is not None:
+        payload["name"] = name
+    if parent_id is not None:
+        payload["parent-id"] = parent_id
+    if archived is not None:
+        payload["archived?"] = archived
+
+    if not payload:
+        return "No fields provided to update."
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        response = await client.post(f"{MOCHI_API_BASE}/decks/{deck_id}", json=payload)
+        response.raise_for_status()
+
+    return f"Updated deck {deck_id}."
+
+
+async def _add_attachment_impl(card_id: str, file_path: str, filename: str | None = None) -> str:
+    """
+    Core implementation for attaching a file to a Mochi card.
+
+    Args:
+        card_id: The Mochi card ID
+        file_path: Path to the local file to upload
+        filename: Name to store the attachment as (defaults to the file's
+            basename); must end in a supported image extension
+
+    Returns:
+        Confirmation message reminding how to reference the attachment
+        from card content
+    """
+    path = Path(file_path)
+    if not path.is_file():
+        raise ValueError(f"File not found: {file_path}")
+
+    resolved_filename = filename or path.name
+    extension = resolved_filename.rsplit(".", 1)[-1].lower() if "." in resolved_filename else ""
+    content_type = ATTACHMENT_CONTENT_TYPES.get(extension)
+    if content_type is None:
+        raise ValueError(
+            f"Unsupported attachment extension '{extension}'. Supported: "
+            f"{', '.join(sorted(ATTACHMENT_CONTENT_TYPES))}"
+        )
+
+    api_key = _get_mochi_api_key()
+    file_bytes = path.read_bytes()
+
+    # Mochi uses HTTP Basic auth: API key as username, blank password.
+    async with httpx.AsyncClient(auth=(api_key, "")) as client:
+        response = await client.post(
+            f"{MOCHI_API_BASE}/cards/{card_id}/attachments/{resolved_filename}",
+            files={"file": (resolved_filename, file_bytes, content_type)},
+        )
+        response.raise_for_status()
+
+    return (
+        f"Attached {resolved_filename} to card {card_id}. "
+        f"Reference it in card content as ![](@media/{resolved_filename})"
+    )
+
+
 # =============================================================================
 # TOOLS - MCP tool wrappers (delegate to core functions)
 # =============================================================================
@@ -449,6 +718,125 @@ async def create_cards(deck_id: str, cards: list[dict]) -> str:
         )
     """
     return await _create_cards_impl(deck_id, cards)
+
+
+@mcp.tool
+async def list_cards(
+    deck_id: str | None = None, limit: int = 100, bookmark: str | None = None
+) -> str:
+    """
+    List Mochi cards, optionally scoped to a deck.
+
+    Use this to browse or search existing cards before editing them. Results
+    are paginated: pass the returned bookmark back in to fetch the next page.
+
+    Args:
+        deck_id: Only return cards from this deck, if given
+        limit: Maximum number of cards to return per page (1-100, default 100)
+        bookmark: Pagination cursor returned by a previous call
+
+    Returns:
+        Formatted list of card IDs and their first content line, plus a
+        bookmark for the next page when more results are available
+    """
+    return await _list_cards_impl(deck_id, limit, bookmark)
+
+
+@mcp.tool
+async def get_card(card_id: str) -> str:
+    """
+    Fetch a single Mochi card's full content, deck, and tags.
+
+    Args:
+        card_id: The Mochi card ID (use list_cards to find this)
+
+    Returns:
+        The card's deck-id, tags, and full markdown content
+    """
+    return await _get_card_impl(card_id)
+
+
+@mcp.tool
+async def update_card(
+    card_id: str,
+    content: str | None = None,
+    deck_id: str | None = None,
+    manual_tags: list[str] | None = None,
+    archived: bool | None = None,
+    trashed: bool | None = None,
+) -> str:
+    """
+    Update a Mochi card. Only provided fields are changed.
+
+    Args:
+        card_id: The Mochi card ID (use list_cards to find this)
+        content: New markdown content, if changing
+        deck_id: Move the card to this deck, if given
+        manual_tags: Replace the card's manual tags, if given
+        archived: Set the card's archived status, if given
+        trashed: Soft-delete (True) or restore (False) the card, if given
+
+    Returns:
+        Confirmation message, or a note that nothing was provided to update
+    """
+    return await _update_card_impl(card_id, content, deck_id, manual_tags, archived, trashed)
+
+
+@mcp.tool
+async def create_deck(name: str, parent_id: str | None = None) -> str:
+    """
+    Create a new Mochi deck.
+
+    Args:
+        name: The deck name
+        parent_id: Nest the new deck under this parent deck, if given
+
+    Returns:
+        Confirmation message with the created deck's name and ID
+    """
+    return await _create_deck_impl(name, parent_id)
+
+
+@mcp.tool
+async def update_deck(
+    deck_id: str,
+    name: str | None = None,
+    parent_id: str | None = None,
+    archived: bool | None = None,
+) -> str:
+    """
+    Update a Mochi deck. Only provided fields are changed.
+
+    Args:
+        deck_id: The Mochi deck ID (use list_decks to find this)
+        name: New deck name, if changing
+        parent_id: Move the deck under this parent deck, if given
+        archived: Set the deck's archived status, if given
+
+    Returns:
+        Confirmation message, or a note that nothing was provided to update
+    """
+    return await _update_deck_impl(deck_id, name, parent_id, archived)
+
+
+@mcp.tool
+async def add_attachment(card_id: str, file_path: str, filename: str | None = None) -> str:
+    """
+    Attach a local image file to a Mochi card.
+
+    Supported extensions: png, jpg, jpeg, gif, svg, webp.
+
+    Args:
+        card_id: The Mochi card ID to attach the file to
+        file_path: Path to the local file to upload
+        filename: Name to store the attachment as (defaults to the file's
+            basename)
+
+    Returns:
+        Confirmation message reminding how to reference the attachment
+        from card content (![](@media/<filename>))
+    """
+    return await _add_attachment_impl(card_id, file_path, filename)
 
 
 # =============================================================================

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,18 +19,30 @@ from mochi_donut.server import (
     EXAMPLE_FLASHCARDS,
     MATUSCHAK_PRINCIPLES,
     SERVER_INSTRUCTIONS,
+    _add_attachment_impl,
     _create_cards_impl,
+    _create_deck_impl,
     _fetch_url_impl,
+    _get_card_impl,
+    _list_cards_impl,
     _list_decks_impl,
+    _update_card_impl,
+    _update_deck_impl,
+    add_attachment,
     create_cards,
+    create_deck,
     fetch_url,
     generate_flashcards,
+    get_card,
     get_examples,
     get_principles,
+    list_cards,
     list_decks,
     main,
     mcp,
     review_flashcards,
+    update_card,
+    update_deck,
 )
 
 
@@ -310,7 +322,9 @@ class TestCreateCardsTool:
         """Non-HTTPStatusError exceptions are captured in the error list."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.post("https://app.mochi.cards/api/cards/").mock(side_effect=httpx.ConnectError("boom"))
+        respx.post("https://app.mochi.cards/api/cards/").mock(
+            side_effect=httpx.ConnectError("boom")
+        )
 
         result = await _create_cards_impl("deck-1", [{"question": "Q1", "answer": "A1"}])
 
@@ -330,6 +344,407 @@ class TestCreateCardsTool:
 
         assert "Created 0/7 cards" in result
         assert "...and 2 more errors" in result
+
+
+class TestListCardsTool:
+    """Test the list_cards tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_cards_success(self, monkeypatch):
+        """Test successful card listing with a bookmark for pagination."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        mock_response = {
+            "docs": [
+                {"id": "card-1", "content": "What is Python?\n---\nA language"},
+                {"id": "card-2", "content": "What is HTTP?\n---\nA protocol"},
+            ],
+            "bookmark": "next-page-token",
+        }
+
+        route = respx.get("https://app.mochi.cards/api/cards/").mock(
+            return_value=Response(200, json=mock_response)
+        )
+
+        result = await _list_cards_impl()
+
+        assert route.calls.last.request.url.path == "/api/cards/"
+        assert "card-1: What is Python?" in result
+        assert "card-2: What is HTTP?" in result
+        assert "next-page-token" in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_cards_no_bookmark_in_response(self, monkeypatch):
+        """When the response has no bookmark, no pagination line is appended."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        respx.get("https://app.mochi.cards/api/cards/").mock(
+            return_value=Response(200, json={"docs": [{"id": "card-1", "content": "Q\n---\nA"}]})
+        )
+
+        result = await _list_cards_impl()
+
+        assert "card-1: Q" in result
+        assert "bookmark" not in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_cards_filters_and_pagination_params(self, monkeypatch):
+        """deck_id, limit, and bookmark are sent as query params."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.get("https://app.mochi.cards/api/cards/").mock(
+            return_value=Response(200, json={"docs": []})
+        )
+
+        await _list_cards_impl(deck_id="deck-1", limit=10, bookmark="cursor-1")
+
+        request = route.calls.last.request
+        assert request.url.params["deck-id"] == "deck-1"
+        assert request.url.params["limit"] == "10"
+        assert request.url.params["bookmark"] == "cursor-1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_cards_empty(self, monkeypatch):
+        """Test empty card list."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        respx.get("https://app.mochi.cards/api/cards/").mock(
+            return_value=Response(200, json={"docs": []})
+        )
+
+        result = await _list_cards_impl()
+
+        assert "No cards found" in result
+
+    @pytest.mark.asyncio
+    async def test_list_cards_no_api_key(self, monkeypatch):
+        """Test error when API key is not set."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _list_cards_impl()
+
+
+class TestGetCardTool:
+    """Test the get_card tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_card_success(self, monkeypatch):
+        """Test fetching a single card's full content, deck-id, and tags."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        mock_card = {
+            "id": "card-1",
+            "content": "What is Python?\n---\nA language",
+            "deck-id": "deck-1",
+            "tags": ["python"],
+            "manual-tags": ["basics"],
+        }
+
+        route = respx.get("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json=mock_card)
+        )
+
+        result = await _get_card_impl("card-1")
+
+        assert route.calls.last.request.url.path == "/api/cards/card-1"
+        assert "card-1" in result
+        assert "deck-1" in result
+        assert "python" in result
+        assert "basics" in result
+        assert "What is Python?\n---\nA language" in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_card_no_tags(self, monkeypatch):
+        """Test a card with no tags at all."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        mock_card = {"id": "card-1", "content": "Q\n---\nA", "deck-id": "deck-1"}
+
+        respx.get("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json=mock_card)
+        )
+
+        result = await _get_card_impl("card-1")
+
+        assert "none" in result
+
+    @pytest.mark.asyncio
+    async def test_get_card_no_api_key(self, monkeypatch):
+        """Test error when API key is not set."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _get_card_impl("card-1")
+
+
+class TestUpdateCardTool:
+    """Test the update_card tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_card_content(self, monkeypatch):
+        """Only provided fields are sent, mapped to Mochi's kebab-case names."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json={"id": "card-1"})
+        )
+
+        result = await _update_card_impl("card-1", content="New content")
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"content": "New content"}
+        assert "Updated card card-1" in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_card_all_fields(self, monkeypatch):
+        """All updatable fields map to Mochi's kebab-case field names."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json={"id": "card-1"})
+        )
+
+        await _update_card_impl(
+            "card-1",
+            content="Q\n---\nA",
+            deck_id="deck-2",
+            manual_tags=["python"],
+            archived=True,
+        )
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["content"] == "Q\n---\nA"
+        assert body["deck-id"] == "deck-2"
+        assert body["manual-tags"] == ["python"]
+        assert body["archived?"] is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_card_trashed_true_sends_timestamp(self, monkeypatch):
+        """trashed=True is sent as an ISO 8601 timestamp, not a boolean."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json={"id": "card-1"})
+        )
+
+        await _update_card_impl("card-1", trashed=True)
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert isinstance(body["trashed?"], str)
+        assert body["trashed?"].endswith("Z")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_card_trashed_false_clears_timestamp(self, monkeypatch):
+        """trashed=False untrashes the card by clearing the timestamp field."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(200, json={"id": "card-1"})
+        )
+
+        await _update_card_impl("card-1", trashed=False)
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["trashed?"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_card_no_fields(self, monkeypatch):
+        """Calling with no fields to update is a no-op that reports back."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        result = await _update_card_impl("card-1")
+
+        assert "No fields provided" in result
+
+    @pytest.mark.asyncio
+    async def test_update_card_no_api_key(self, monkeypatch):
+        """Test error when API key is not set."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _update_card_impl("card-1", content="x")
+
+
+class TestCreateDeckTool:
+    """Test the create_deck tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_deck_success(self, monkeypatch):
+        """Test successful deck creation."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/decks/").mock(
+            return_value=Response(200, json={"id": "deck-1", "name": "Python"})
+        )
+
+        result = await _create_deck_impl("Python")
+
+        assert route.calls.last.request.url.path == "/api/decks/"
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"name": "Python"}
+        assert "Python" in result
+        assert "deck-1" in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_deck_with_parent(self, monkeypatch):
+        """parent_id maps to Mochi's parent-id field."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/decks/").mock(
+            return_value=Response(200, json={"id": "deck-2", "name": "Subdeck"})
+        )
+
+        await _create_deck_impl("Subdeck", parent_id="deck-1")
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["parent-id"] == "deck-1"
+
+    @pytest.mark.asyncio
+    async def test_create_deck_no_api_key(self, monkeypatch):
+        """Test error when API key is not set."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _create_deck_impl("Python")
+
+
+class TestUpdateDeckTool:
+    """Test the update_deck tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_deck_fields(self, monkeypatch):
+        """Only provided fields are sent, mapped to Mochi's kebab-case names."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        route = respx.post("https://app.mochi.cards/api/decks/deck-1").mock(
+            return_value=Response(200, json={"id": "deck-1"})
+        )
+
+        result = await _update_deck_impl(
+            "deck-1", name="Renamed", parent_id="deck-0", archived=True
+        )
+
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"name": "Renamed", "parent-id": "deck-0", "archived?": True}
+        assert "Updated deck deck-1" in result
+
+    @pytest.mark.asyncio
+    async def test_update_deck_no_fields(self, monkeypatch):
+        """Calling with no fields to update is a no-op that reports back."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        result = await _update_deck_impl("deck-1")
+
+        assert "No fields provided" in result
+
+    @pytest.mark.asyncio
+    async def test_update_deck_no_api_key(self, monkeypatch):
+        """Test error when API key is not set."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _update_deck_impl("deck-1", name="x")
+
+
+class TestAddAttachmentTool:
+    """Test the add_attachment tool implementation."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_add_attachment_success(self, monkeypatch, tmp_path):
+        """Test successful attachment upload, inferring filename and content-type."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        image_path = tmp_path / "diagram.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1/attachments/diagram.png").mock(
+            return_value=Response(200, json={})
+        )
+
+        result = await _add_attachment_impl("card-1", str(image_path))
+
+        assert route.calls.last.request.url.path == ("/api/cards/card-1/attachments/diagram.png")
+        assert "diagram.png" in result
+        assert "@media/diagram.png" in result
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_add_attachment_custom_filename(self, monkeypatch, tmp_path):
+        """An explicit filename overrides the file's basename."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        image_path = tmp_path / "source.jpg"
+        image_path.write_bytes(b"fake-jpg-bytes")
+
+        route = respx.post("https://app.mochi.cards/api/cards/card-1/attachments/renamed.jpg").mock(
+            return_value=Response(200, json={})
+        )
+
+        result = await _add_attachment_impl("card-1", str(image_path), filename="renamed.jpg")
+
+        assert route.calls.last.request.url.path == ("/api/cards/card-1/attachments/renamed.jpg")
+        assert "renamed.jpg" in result
+
+    @pytest.mark.asyncio
+    async def test_add_attachment_file_not_found(self, monkeypatch, tmp_path):
+        """Test validation error when the file doesn't exist."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        missing_path = tmp_path / "missing.png"
+
+        with pytest.raises(ValueError, match="File not found"):
+            await _add_attachment_impl("card-1", str(missing_path))
+
+    @pytest.mark.asyncio
+    async def test_add_attachment_unsupported_extension(self, monkeypatch, tmp_path):
+        """Test validation error for an unsupported file extension."""
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+
+        bad_path = tmp_path / "document.pdf"
+        bad_path.write_bytes(b"fake-pdf-bytes")
+
+        with pytest.raises(ValueError, match="Unsupported attachment extension"):
+            await _add_attachment_impl("card-1", str(bad_path))
+
+    @pytest.mark.asyncio
+    async def test_add_attachment_no_api_key(self, monkeypatch, tmp_path):
+        """Test error when API key is not set (validated after file checks)."""
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+
+        image_path = tmp_path / "diagram.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        with pytest.raises(ValueError, match="MOCHI_API_KEY"):
+            await _add_attachment_impl("card-1", str(image_path))
 
 
 class TestServerConfiguration:
@@ -364,6 +779,12 @@ class TestServerConfiguration:
         assert await mcp.get_tool("fetch_url") is not None
         assert await mcp.get_tool("list_decks") is not None
         assert await mcp.get_tool("create_cards") is not None
+        assert await mcp.get_tool("list_cards") is not None
+        assert await mcp.get_tool("get_card") is not None
+        assert await mcp.get_tool("update_card") is not None
+        assert await mcp.get_tool("create_deck") is not None
+        assert await mcp.get_tool("update_deck") is not None
+        assert await mcp.get_tool("add_attachment") is not None
 
 
 class TestToolWrappers:
@@ -394,6 +815,52 @@ class TestToolWrappers:
     async def test_create_cards_tool_wrapper(self, monkeypatch):
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
         assert "No cards provided" in await create_cards("deck-1", [])
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_cards_tool_wrapper(self, monkeypatch):
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+        respx.get("https://app.mochi.cards/api/cards/").mock(
+            return_value=Response(200, json={"docs": []})
+        )
+        assert "No cards found" in await list_cards()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_card_tool_wrapper(self, monkeypatch):
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+        respx.get("https://app.mochi.cards/api/cards/card-1").mock(
+            return_value=Response(
+                200, json={"id": "card-1", "content": "Q\n---\nA", "deck-id": "d"}
+            )
+        )
+        assert "card-1" in await get_card("card-1")
+
+    @pytest.mark.asyncio
+    async def test_update_card_tool_wrapper(self, monkeypatch):
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+        assert "No fields provided" in await update_card("card-1")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_deck_tool_wrapper(self, monkeypatch):
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+        respx.post("https://app.mochi.cards/api/decks/").mock(
+            return_value=Response(200, json={"id": "deck-1", "name": "Python"})
+        )
+        assert "deck-1" in await create_deck("Python")
+
+    @pytest.mark.asyncio
+    async def test_update_deck_tool_wrapper(self, monkeypatch):
+        monkeypatch.setenv("MOCHI_API_KEY", "test-key")
+        assert "No fields provided" in await update_deck("deck-1")
+
+    @pytest.mark.asyncio
+    async def test_add_attachment_tool_wrapper(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MOCHI_API_KEY", raising=False)
+        missing_path = tmp_path / "missing.png"
+        with pytest.raises(ValueError, match="File not found"):
+            await add_attachment("card-1", str(missing_path))
 
 
 class TestEntryPoint:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,12 +169,15 @@ class TestListDecksTool:
             "docs": [{"id": "deck-1", "name": "Python"}, {"id": "deck-2", "name": "JavaScript"}]
         }
 
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        # Mochi's router requires the trailing slash: /api/decks/ 200s while
+        # /api/decks 404s even with a valid key.
+        route = respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json=mock_response)
         )
 
         result = await _list_decks_impl()
 
+        assert route.calls.last.request.url.path == "/api/decks/"
         assert "Python: deck-1" in result
         assert "JavaScript: deck-2" in result
 
@@ -184,7 +187,7 @@ class TestListDecksTool:
         """Test empty deck list."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json={"docs": []})
         )
 
@@ -210,7 +213,7 @@ class TestCreateCardsTool:
         """Test successful card creation."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.post("https://app.mochi.cards/api/cards").mock(
+        respx.post("https://app.mochi.cards/api/cards/").mock(
             return_value=Response(200, json={"id": "card-123"})
         )
 
@@ -232,7 +235,7 @@ class TestCreateCardsTool:
 
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        route = respx.post("https://app.mochi.cards/api/cards").mock(
+        route = respx.post("https://app.mochi.cards/api/cards/").mock(
             return_value=Response(200, json={"id": "card-123"})
         )
 
@@ -242,6 +245,9 @@ class TestCreateCardsTool:
 
         request = route.calls.last.request
         body = json.loads(request.content)
+
+        # Mochi's router requires the trailing slash on /api/cards/.
+        assert request.url.path == "/api/cards/"
 
         # Tags use Mochi's "manual-tags" key.
         assert body["manual-tags"] == ["python", "basics"]
@@ -272,7 +278,7 @@ class TestCreateCardsTool:
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
         # First card succeeds, second fails
-        route = respx.post("https://app.mochi.cards/api/cards")
+        route = respx.post("https://app.mochi.cards/api/cards/")
         route.side_effect = [
             Response(200, json={"id": "card-1"}),
             Response(400, text="Invalid card"),
@@ -304,7 +310,7 @@ class TestCreateCardsTool:
         """Non-HTTPStatusError exceptions are captured in the error list."""
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
 
-        respx.post("https://app.mochi.cards/api/cards").mock(side_effect=httpx.ConnectError("boom"))
+        respx.post("https://app.mochi.cards/api/cards/").mock(side_effect=httpx.ConnectError("boom"))
 
         result = await _create_cards_impl("deck-1", [{"question": "Q1", "answer": "A1"}])
 
@@ -379,7 +385,7 @@ class TestToolWrappers:
     @pytest.mark.asyncio
     async def test_list_decks_tool_wrapper(self, monkeypatch):
         monkeypatch.setenv("MOCHI_API_KEY", "test-key")
-        respx.get("https://app.mochi.cards/api/decks").mock(
+        respx.get("https://app.mochi.cards/api/decks/").mock(
             return_value=Response(200, json={"docs": []})
         )
         assert "No decks found" in await list_decks()

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "mochi-donut"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "mochi-donut"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Fixes a pre-existing bug: `list_decks` and `create_cards` now request `/api/decks/` and `/api/cards/` with the required trailing slash (Mochi's router 404s without it, even with a valid API key).
- Adds six new MCP tools for managing existing Mochi content instead of only creating cards once:
  - `list_cards(deck_id=None, limit=100, bookmark=None)` — GET `/cards/`, returns card id + first content line, plus the pagination `bookmark`.
  - `get_card(card_id)` — GET `/cards/{id}`, returns full content, `deck-id`, `tags`, and `manual-tags`.
  - `update_card(card_id, content=None, deck_id=None, manual_tags=None, archived=None, trashed=None)` — POST `/cards/{id}` with only the provided fields, mapped to Mochi's kebab-case names. `trashed?` is sent as an ISO 8601 timestamp (Mochi's soft-delete representation), not a boolean — verified against https://mochi.cards/docs/api/.
  - `create_deck(name, parent_id=None)` — POST `/decks/`.
  - `update_deck(deck_id, name=None, parent_id=None, archived=None)` — POST `/decks/{id}`, only provided fields.
  - `add_attachment(card_id, file_path, filename=None)` — POST `/cards/{card_id}/attachments/{filename}` as multipart/form-data (form field `file`, per the docs), validating the file exists and has a supported extension (png/jpg/jpeg/gif/svg/webp), inferring content-type, and reminding the caller to reference it as `![](@media/<filename>)`.
- Updates `SERVER_INSTRUCTIONS`, the module docstring, `README.md`, and `CLAUDE.md` to list the new tools.
- Bumps version 0.3.1 → 0.4.0 with a matching `CHANGELOG.md` entry.

## Test plan
- [x] TDD: failing tests written first for every new tool (import errors confirmed before implementation existed)
- [x] `uv run pytest` — 64 passed, 100% line and branch coverage
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy src` — no issues
- [x] `uv run ty check src` — all checks passed

Exact pytest summary:
```
64 passed, 1 warning in 1.56s
Required test coverage of 100% reached. Total coverage: 100.00%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)